### PR TITLE
SST Method checking throughout the cluster

### DIFF
--- a/s9s/mysql/galera/wsrep_sst_method.js
+++ b/s9s/mysql/galera/wsrep_sst_method.js
@@ -10,7 +10,8 @@ function main()
 {
     var hosts     = cluster::galeraNodes();
     var advisorMap = {};
-
+    var sst_method = "";
+    var alarmMessage;
     for (idx = 0; idx < hosts.size(); idx++)
     {
         host        = hosts[idx];
@@ -29,6 +30,7 @@ function main()
         var msg ="";
         var justification = "";
         var advice = new CmonAdvice();
+        var raiseAlarm = false;
         advice.setTitle("Wsrep SST method");
         advice.setHost(host);
         var value = host.sqlSystemVariable("WSREP_SST_METHOD").toString();
@@ -47,11 +49,11 @@ function main()
         {
             retval = host.system("test -f /usr/bin/wsrep_sst_xtrabackup-v2");
             reply = retval["success"];
-            var raiseAlarm = false;
             if (reply)
             {
                 raiseAlarm = true;
-                msg="Use wsrep_sst_method=xtrabackup-v2 instead.";
+                msg="Use wsrep_sst_method=xtrabackup-v2 or mariabackup"
+                " (for newer version of MariaDb) instead.";
                 advice.setSeverity(Warning);
             }
             else
@@ -62,16 +64,33 @@ function main()
             }
             justification = "Current wsrep_sst_method=" + value;
             advice.setJustification(justification);
-            if (raiseAlarm)
-                host.raiseAlarm(MySqlAdvisor, Warning, msg);
+
         }
         else
         {
-            msg="Using wsrep_sst_method=" + value + ", so it is good.";
-            advice.setSeverity(Ok);
-            justification = "Current wsrep_sst_method=" + value;
-            advice.setJustification(justification);
-            host.clearAlarm(MySqlAdvisor);
+            if (sst_method == "") {
+                sst_method = value;
+            }
+            if (sst_method != value) {
+                raiseAlarm = true;
+                msg="The wsrep_sst_method is not the same throughout the cluster "
+		    "and this could lead to incompatible state transfers";
+                justification = "Current wsrep_sst_method=" + value;
+                advice.setJustification(justification);
+                advice.setSeverity(Warning); 
+            }
+            else {
+                msg="Using wsrep_sst_method=" + value + ", so it is good.";
+                advice.setSeverity(Ok);
+                justification = "Current wsrep_sst_method=" + value;
+                advice.setJustification(justification);
+                host.clearAlarm(MySqlAdvisor);
+            }
+        }
+        if (raiseAlarm)
+        {
+            alarmMessage = justification + "\n" + msg;
+            host.raiseAlarm(MySqlAdvisor, Warning, alarmMessage);
         }
         advice.setAdvice(msg);
         advisorMap[idx]= advice;
@@ -79,5 +98,7 @@ function main()
     }
     return advisorMap;
 }
+
+
 
 

--- a/s9s/mysql/galera/wsrep_sst_method.js
+++ b/s9s/mysql/galera/wsrep_sst_method.js
@@ -64,7 +64,6 @@ function main()
             }
             justification = "Current wsrep_sst_method=" + value;
             advice.setJustification(justification);
-
         }
         else
         {
@@ -74,12 +73,28 @@ function main()
             if (sst_method != value) {
                 raiseAlarm = true;
                 msg="The wsrep_sst_method is not the same throughout the cluster "
-		    "and this could lead to incompatible state transfers";
+                "and this could lead to incompatible state transfers.";
                 justification = "Current wsrep_sst_method=" + value;
                 advice.setJustification(justification);
                 advice.setSeverity(Warning); 
             }
             else {
+                if (value == "mariabackup") {
+                    retval = host.system("test -f /usr/bin/mariabackup");
+                    reply = retval["success"];
+                    if (!reply)
+                    {
+                        raiseAlarm = true;
+                        msg="The wsrep_sst_method is set to mariabackup but "
+                        "/usr/bin/mariabackup does not exist. "
+                        "Please install the MariaDB Backup package.";
+                        justification = "Current wsrep_sst_method=" + value;
+                        advice.setJustification(justification);
+                        advice.setSeverity(Warning);
+                    }
+                }
+            }
+            if (!raiseAlarm) {
                 msg="Using wsrep_sst_method=" + value + ", so it is good.";
                 advice.setSeverity(Ok);
                 justification = "Current wsrep_sst_method=" + value;


### PR DESCRIPTION
If the SST method is set to different methods (xtrabackup and mariadbbackup) inside the cluster, the advisor would still tell us that everything is fine. If we would be running MariaDB with compression or encryption, the SST would not be compatible between nodes if the donor would be configured with mariadbbackup and the receiver with xtrabackup. 
I adjusted the advisor to alert if the method is not the same throughout the cluster.