### PR TITLE
Adding a new advisor: checking if a .sst directory exists on Galera

### DIFF
--- a/s9s/mysql/galera/check_sst_dir.js
+++ b/s9s/mysql/galera/check_sst_dir.js
@@ -1,0 +1,57 @@
+#include "common/mysql_helper.js"
+
+var DESCRIPTION="This advisor scans the MySQL data directory and notifies you"
+                " if a .sst directory exists. This directory sometimes appears"
+                " after a failed SST which wasn't cleaned up properly. If the"
+                " direcory exists, a new SST will fail.";
+function main()
+{
+    var hosts     = cluster::galeraNodes();
+    var advisorMap = {};
+
+    for (idx = 0; idx < hosts.size(); idx++)
+    {
+        host        = hosts[idx];
+        map         = host.toMap();
+
+        var msg ="";
+        var advice = new CmonAdvice();
+        advice.setTitle(".SST Directory Checker");
+        advice.setHost(host);
+        justification = "";
+
+        var datadir = host.dataDir();
+        if (datadir == "")
+            continue;
+
+        var retval = host.system("find " + datadir + 
+                                 " -maxdepth 1 -name '.sst' | wc -l");
+        nr_files = retval["result"];
+        
+        if(nr_files.toInt() == 0) {
+            msg = "Nothing to do. No .sst directory found.";
+            advice.setSeverity(Ok);
+            justification = "Galera host does not have a .sst directory in the"
+                            " MySQL data directory.";
+        }
+        else {
+            justification = "Found a .sst direcory in the MySQL data directory (" + datadir +").";
+            advice.setSeverity(Warning);
+            msg = "The Galera host contains a .sst directory in the"
+              " MySQL data directory. <br/>This directory is"
+              " created whenever there is a state transfer, but normally is cleaned"
+              " up after completion. The existence of this directory means during"
+              " the transfer something went wrong and the directory wasn't cleaned"
+              " up properly. This will block any new state transfer, as the"
+              " transfer will check if this directory already exists and, if it"
+              " does, dies.<br/> A simple removal of this directory will solve this.";
+        }
+        advice.setAdvice(msg);
+        advice.setJustification(justification);
+        advisorMap[idx]= advice;
+    }
+
+    return advisorMap;
+}
+
+


### PR DESCRIPTION
We found out that if a .sst directory exists on Galera, this may block any consecutive SST processes. The SST process will check if the directory exists and remove if it does. For some reason it wasn't able to do so and died. 
We think the .sst directory was a remnant of a failed SST process (disk full?) and having a check would prevent this from happening again. I found a similar issue in the MariaDB bugtracker:
https://jira.mariadb.org/browse/MDEV-9884